### PR TITLE
Fixed use Pdo native cakephp trait

### DIFF
--- a/src/Driver/Oracle.php
+++ b/src/Driver/Oracle.php
@@ -20,7 +20,6 @@
 namespace Cake\Oracle\Driver;
 
 use Cake\Database\Driver;
-use Cake\Database\Driver\PDODriverTrait;
 use Cake\Database\Query;
 use Cake\Database\Statement\PDOStatement;
 use Cake\Oracle\Dialect\OracleDialectTrait;
@@ -34,7 +33,6 @@ use Yajra\Pdo\Oci8;
 class Oracle extends Driver
 {
     use OracleDialectTrait;
-    use PDODriverTrait;
 
     protected $_baseConfig = [
         'flags' => [],


### PR DESCRIPTION
Fixed use Pdo native cakephp trait.

``
Strict (2048): Cake\Database\Driver and Cake\Database\Driver\PDODriverTrait define the same property ($_connection) in the composition of Cake\Oracle\Driver\Oracle. This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed [ROOT\vendor\snelg\cakephp-3-oracle\src\Driver\Oracle.php, line 237]
``