### PR TITLE
NUMBER without DATA_PRECISION as decimal

### DIFF
--- a/src/Schema/OracleSchema.php
+++ b/src/Schema/OracleSchema.php
@@ -116,7 +116,9 @@ class OracleSchema extends BaseSchema
                 $field = ['type' => 'timestamp', 'length' => null];
                 break;
             case 'NUMBER':
-                if ($row['DATA_PRECISION'] == 1) {
+                if ($row['DATA_PRECISION'] == null) {
+                    $field = ['type' => 'decimal', 'length' => $row['DATA_LENGTH']];
+                } elseif ($row['DATA_PRECISION'] == 1) {
                     $field = ['type' => 'boolean', 'length' => null];
                 } else {
                     if ($row['DATA_SCALE'] > 0) {


### PR DESCRIPTION
When NUMBER not have DATA_PRECISION then field is decimal:
https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#CNCPT1832
If a precision is not specified, the column stores values as given.

[Table 26-1](https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#g23242) shows examples of how data would be stored using different scale factors.